### PR TITLE
Don't suspend OpenXR instance/session on shutdown state change

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -326,9 +326,9 @@ pub fn xr_begin_frame(
                                 session_running.store(true, std::sync::atomic::Ordering::Relaxed);
                             }
                             xr::SessionState::STOPPING => {
-                                session.end().unwrap();
-                                session_running.store(false, std::sync::atomic::Ordering::Relaxed);
-                                app_exit.send(AppExit);
+                                // session.end().unwrap();
+                                // session_running.store(false, std::sync::atomic::Ordering::Relaxed);
+                                // app_exit.send(AppExit);
                             }
                             xr::SessionState::EXITING | xr::SessionState::LOSS_PENDING => {
                                 app_exit.send(AppExit);


### PR DESCRIPTION
This is hacky as fuck but is necessary for dynamically invoking scene scanning.

When we request scene capture during the app, the xr session state goes to `xr::SessionState::STOPPING`, as the app gets backgrounded by the dialog that appears. `bevy_oxr` handles this correctly according to the OpenXR spec by suspending the XrSession and XrInstance tied to the application.

However we need to be able to resume our app with the XrInstance and XrSession after this dialog has occured, which means that we need the session and instance to not be killed off when this happens.